### PR TITLE
Fiddles with ravend download script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
     "url": "https://github.com/RavenDevKit/ravencore-node/issues"
   },
   "bin": {
-    "ravencore-node": "./bin/ravencore-node",
-    "ravend": "./bin/ravend"
+    "ravencore-node": "./bin/ravencore-node"
   },
   "scripts": {
-    "download": "./scripts/download",
-    "verify": "./scripts/download --skip-ravencoin-download --verify-ravencoin-download",
+    "preinstall": "./scripts/download",
+    "download-ravend": "./scripts/download",
+    "verify-ravend": "./scripts/download --skip-ravencoin-download --verify-ravencoin-download",
     "test": "mocha -R spec --recursive",
     "regtest": "./scripts/regtest",
     "jshint": "jshint --reporter=node_modules/jshint-stylish ./lib",

--- a/scripts/download
+++ b/scripts/download
@@ -35,6 +35,11 @@ download_ravend() {
 
     cd "${root_dir}/bin"
 
+    if test -e "ravend"; then
+        echo "\"bin/ravend\" already exists -- skipping download."
+        return;
+    fi
+
     echo "Downloading ravencoin: ${binary_url}"
 
     is_curl=true


### PR DESCRIPTION
* added download back to NPM preinstall script
* download aborts if bin/ravend already exists
* renamed NPM scripts to `download-ravend` and `verify-ravend` to be more specific